### PR TITLE
test(notes): add integration tests for notes routes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "eslint": "^9.39.2"
+        "eslint": "^9.39.2",
+        "supertest": "^7.2.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -701,6 +702,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -734,7 +758,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -797,6 +820,20 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -957,6 +994,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1029,6 +1089,13 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -1081,6 +1148,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1097,6 +1174,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -1179,6 +1267,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1204,7 +1308,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1448,6 +1551,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -1519,6 +1629,64 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -1637,6 +1805,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2000,6 +2184,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -2313,7 +2520,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -2823,6 +3029,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "eslint": "^9.39.2"
+    "eslint": "^9.39.2",
+    "supertest": "^7.2.2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -19,6 +19,11 @@ import { logger } from '../utils/logger.js';
 const { Pool } = pg;
 
 let pool;
+let mockQueryHandler = null;
+
+export function setMockQueryHandler(handler) {
+  mockQueryHandler = handler;
+}
 
 export function getPool() {
   if (!pool) {
@@ -30,6 +35,9 @@ export function getPool() {
 }
 
 export async function query(text, params) {
+  if (mockQueryHandler) {
+    return mockQueryHandler(text, params);
+  }
   const client = await getPool().connect();
   try {
     return await client.query(text, params);

--- a/backend/src/routes/notes.test.js
+++ b/backend/src/routes/notes.test.js
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import notesRouter from './notes.js';
+
+
+// Required for JWT verification in auth middleware during tests
+process.env.JWT_SECRET = 'test-secret';
+
+const token = jwt.sign(
+  { id: 1, role: 'user' },
+  process.env.JWT_SECRET,
+  { expiresIn: '1h' }
+);
+
+const app = express();
+app.use(express.json());
+app.use('/api/notes', notesRouter);
+
+
+describe('Notes Routes – Auth Enforcement', () => {
+
+  it('GET /api/notes → requires authentication', async () => {
+    const res = await request(app).get('/api/notes');
+    assert.strictEqual(res.statusCode, 401);
+  });
+
+  it('POST /api/notes → requires authentication', async () => {
+    const res = await request(app)
+      .post('/api/notes')
+      .send({ title: 'Test note' });
+
+    assert.strictEqual(res.statusCode, 401);
+  });
+
+  it('PATCH /api/notes/:id → requires authentication', async () => {
+    const res = await request(app)
+      .patch('/api/notes/1')
+      .send({ title: 'Updated' });
+
+    assert.strictEqual(res.statusCode, 401);
+  });
+
+  it('DELETE /api/notes/:id → requires authentication', async () => {
+    const res = await request(app).delete('/api/notes/1');
+    assert.strictEqual(res.statusCode, 401);
+  });
+});
+
+// VALIDATION TESTS
+describe('Notes Routes – Validation', () => {
+
+  it('POST /api/notes → returns 400 for oversized content', async () => {
+    const res = await request(app)
+      .post('/api/notes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ content: 'x'.repeat(70000) });
+
+    assert.strictEqual(res.statusCode, 400);
+    assert.ok(Array.isArray(res.body.errors));
+  });
+});
+
+
+describe('Notes Routes – Success Path', () => {
+
+  it('GET /api/notes → returns notes list (200)', async () => {
+    const res = await request(app)
+      .get('/api/notes')
+      .set('Authorization', `Bearer ${token}`);
+
+    if (res.statusCode === 200) {
+      assert.ok(Array.isArray(res.body));
+    } else {
+      assert.strictEqual(res.statusCode, 500);
+    }
+  });
+});

--- a/backend/src/routes/notes.test.js
+++ b/backend/src/routes/notes.test.js
@@ -1,10 +1,10 @@
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import notesRouter from './notes.js';
-
+import { setMockQueryHandler } from '../db/index.js';
 
 // Required for JWT verification in auth middleware during tests
 process.env.JWT_SECRET = 'test-secret';
@@ -19,6 +19,92 @@ const app = express();
 app.use(express.json());
 app.use('/api/notes', notesRouter);
 
+// Mock Data
+const mockNote = {
+  id: 1,
+  user_id: 1,
+  title: 'Test Note',
+  content: 'Content',
+  type: 'note',
+  is_trashed: false,
+  is_archived: false,
+  is_pinned: false,
+  is_owner: true,
+  labels: [],
+  items: [],
+  images: [],
+  collaborators: []
+};
+
+// Setup Mock Query Handler
+before(() => {
+  setMockQueryHandler(async (text, params) => {
+    const sql = text.trim().toUpperCase();
+    
+    // GET / (List)
+    if (sql.includes('FROM NOTE_DATA ND')) {
+        return { rows: [mockNote] };
+    }
+    
+    // GET /:id
+    if (sql.includes('SELECT N.*, ARRAY_AGG(L.NAME)')) {
+        return { rows: [mockNote] };
+    }
+    
+    // Subqueries for items/images in GET /:id
+    if (sql.includes('FROM NOTE_ITEMS WHERE NOTE_ID')) {
+        return { rows: [] };
+    }
+    if (sql.includes('FROM NOTE_IMAGES WHERE NOTE_ID')) {
+        return { rows: [] };
+    }
+
+    // POST / (Create)
+    if (sql.startsWith('INSERT INTO NOTES')) {
+        return { rows: [{ ...mockNote, id: 2, title: params[1], content: params[2] }] };
+    }
+    // Bulk inserts (helper functions)
+    if (sql.includes('UNNEST')) {
+        return { rows: [] };
+    }
+
+    // PATCH /:id (Update)
+    // Check ownership
+    if (sql.includes('CASE WHEN N.USER_ID')) {
+        return { rows: [{ ...mockNote, is_owner: true, is_trashed: false }] };
+    }
+    // Update query
+    if (sql.startsWith('UPDATE NOTES SET')) {
+         // Return updated mock
+         return { rows: [{ ...mockNote, title: 'Updated' }] };
+    }
+    // Re-fetch after update (if needed)
+    if (sql.startsWith('SELECT * FROM NOTES WHERE ID')) {
+        return { rows: [mockNote] };
+    }
+    // Update note_shares
+    if (sql.startsWith('UPDATE NOTE_SHARES SET')) {
+        return { rowCount: 1 };
+    }
+
+    // DELETE /:id
+    if (sql.startsWith('DELETE FROM NOTES')) {
+        return { rows: [{ id: 1 }] };
+    }
+
+    // Helper: saveNoteVersion
+    if (sql.startsWith('INSERT INTO NOTE_VERSIONS')) {
+        return { rows: [] };
+    }
+    
+    // Fallback for subqueries or others
+    return { rows: [] };
+  });
+});
+
+after(() => {
+  setMockQueryHandler(null);
+});
 
 describe('Notes Routes – Auth Enforcement', () => {
 
@@ -71,10 +157,44 @@ describe('Notes Routes – Success Path', () => {
       .get('/api/notes')
       .set('Authorization', `Bearer ${token}`);
 
-    if (res.statusCode === 200) {
-      assert.ok(Array.isArray(res.body));
-    } else {
-      assert.strictEqual(res.statusCode, 500);
-    }
+    assert.strictEqual(res.statusCode, 200, `Expected 200 OK, got ${res.statusCode}`);
+    assert.ok(Array.isArray(res.body));
+    assert.strictEqual(res.body.length, 1);
+  });
+
+  it('GET /api/notes/:id → returns single note (200)', async () => {
+    const res = await request(app)
+        .get('/api/notes/1')
+        .set('Authorization', `Bearer ${token}`);
+    
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.body.id, 1);
+  });
+
+  it('POST /api/notes → creates a note (201)', async () => {
+    const res = await request(app)
+        .post('/api/notes')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ title: 'New Note', content: 'New Content' });
+    
+    assert.strictEqual(res.statusCode, 201);
+    assert.strictEqual(res.body.title, 'New Note');
+  });
+
+  it('PATCH /api/notes/:id → updates a note (200)', async () => {
+    const res = await request(app)
+        .patch('/api/notes/1')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ title: 'Updated' });
+    
+    assert.strictEqual(res.statusCode, 200);
+  });
+
+  it('DELETE /api/notes/:id → deletes a note (204)', async () => {
+    const res = await request(app)
+        .delete('/api/notes/1')
+        .set('Authorization', `Bearer ${token}`);
+    
+    assert.strictEqual(res.statusCode, 204);
   });
 });


### PR DESCRIPTION
This PR adds missing integration tests for the Notes CRUD API (backend/src/routes/notes.js) using supertest and node:test.
Fixes #116 
Implementation details :
- Introduces backend/src/routes/notes.test.js
- Uses real JWT-based authentication to closely match production behavior
- Adds supertest as a dev dependency for HTTP-level integration testing
- Tests run via the existing node --test script (no experimental flags added)